### PR TITLE
Check for new puzzles when selecting a new one

### DIFF
--- a/makenian.py
+++ b/makenian.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import os
+import os.path
 from dotenv import load_dotenv
 import random
 import time
@@ -35,29 +36,62 @@ def read_nine_letter_words(dictionary_file):
     all_words = [x.strip() for x in dictionary]
     return nine_letter_words(all_words)
 
-def select_word(words):
-    return random.choice(words)
+def select_word(words, previous_puzzles):
+    word = random.choice(words).upper()
+    sorted_letters = ''.join(sorted(word))
 
-def find_puzzle(words):
-    word = select_word(words)
+    attempts = 0
+    while sorted_letters in previous_puzzles:
+        print(f'Skipping seen nian {word}, and selecting another one')
+        word = random.choice(words)
+        sorted_letters = ''.join(sorted(word))
+        attempts += 1
+
+        if attempts > 10:
+            print(f'Made 10 attempts at selecting nian, but found only puzzles that have already been used; will use {word} anyway')
+            return word
+
+    return word
+
+def find_puzzle(words, previous_puzzles):
+    word = select_word(words, previous_puzzles)
     puzzles = [generate_puzzle(word) for i in range(100)]
     good_enough = [puzzle for puzzle in puzzles if similarity(word, puzzle) < 0.5]
     return random.choice(good_enough).upper()
 
-def generate_and_upload(webhook_url, dictionary):
-    puzzle = find_puzzle(dictionary)
+def generate_and_upload(webhook_url, dictionary, previous_puzzles):
+    puzzle = find_puzzle(dictionary, previous_puzzles)
     payload = {"text": f"!sättnian {puzzle}"}
     print(f"Uploading nian to {webhook_url} with payload {payload}")
     requests.post(webhook_url, json=payload)
+
+    return puzzle
+
+def read_previous_puzzles(previous_puzzles_file):
+    if not os.path.isfile(previous_puzzles_file):
+        return set()
+
+    with open(previous_puzzles_file, 'r') as fh:
+        previous_puzzles = fh.readlines()
+
+    return {puzzle.strip() for puzzle in previous_puzzles}
+
+def mark_puzzle_seen(previous_puzzles_file, puzzle):
+    with open(previous_puzzles_file,'a') as fh:
+        fh.write(''.join(sorted(puzzle)))
+        fh.write('\n')
 
 if __name__ == "__main__":
     load_dotenv()
     webhook_url = os.getenv("SLACK_WEBHOOK_URL")
     dictionary_file = os.getenv("DICTIONARY_FILE")
+    previous_puzzles_file = os.getenv("PREVIOUS_PUZZLES_FILE")
 
     # Seed random generator to get different puzzles on each invocation.
     random.seed(time.time())
 
     dictionary = read_nine_letter_words(dictionary_file)
+    previous_puzzles = read_previous_puzzles(previous_puzzles_file)
+    puzzle = generate_and_upload(webhook_url, dictionary, previous_puzzles)
 
-    generate_and_upload(webhook_url, dictionary)
+    mark_puzzle_seen(previous_puzzles_file, puzzle)

--- a/makenian.py
+++ b/makenian.py
@@ -37,20 +37,16 @@ def read_nine_letter_words(dictionary_file):
     return nine_letter_words(all_words)
 
 def select_word(words, previous_puzzles):
-    word = random.choice(words).upper()
-    sorted_letters = ''.join(sorted(word))
-
-    attempts = 0
-    while sorted_letters in previous_puzzles:
-        print(f'Skipping seen nian {word}, and selecting another one')
-        word = random.choice(words)
+    for attempts in range(10):
+        word = random.choice(words).upper()
         sorted_letters = ''.join(sorted(word))
-        attempts += 1
 
-        if attempts > 10:
-            print(f'Made 10 attempts at selecting nian, but found only puzzles that have already been used; will use {word} anyway')
+        if sorted_letters not in previous_puzzles:
             return word
 
+        print(f'Skipping seen nian {word}, and selecting another one')
+
+    print(f'Made 10 attempts at selecting nian, but found only puzzles that have already been used; will use {word} anyway')
     return word
 
 def find_puzzle(words, previous_puzzles):


### PR DESCRIPTION
Each time a puzzle is generated, it is noted down in a file, and subsequent runs checks the content of that file to avoid generating already-seen puzzles.

To avoid having to find all solutions to a puzzle when comparing, the letters are sorted before comparing; e.g., if we have previously generated a puzzle from the word SALTINTAG, we will not allow generating one from ANTASTLIG or LASTINTAG, since no matter which order the letters are in the posted puzzle, all three solutions will be valid.

In order for this to work, the script now needs an additional environment variable `PREVIOUS_PUZZLES_FILE`, with a path to the file where previous puzzles are noted down. If the file does not exist it will be created on first write, but the folder structure to keep it must already be there.
